### PR TITLE
Run backend_build after frontend_e2e

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -44,20 +44,18 @@ stages:
 
   - stage: backend_build
     dependsOn:
-      - frontend_build
+      - frontend_e2e
     jobs:
       - template: jobs/backend_build_and_test.yml
 
   - stage: docker_build
     dependsOn:
-      - frontend_build
       - backend_build
     jobs:
       - template: jobs/docker_build.yml
 
   - stage: e2e_test
     dependsOn:
-      - frontend_e2e
       - docker_build
     jobs:
       - template: jobs/e2e_test.yml
@@ -74,6 +72,5 @@ stages:
   - stage: Code_Coverage
     dependsOn:
       - backend_build
-      - frontend_test
     jobs:
       - template: jobs/coverage.yml


### PR DESCRIPTION
Only when frontend tests are done, build the backend, as it's package includes the frontend.
Especially for private repos, where parallel jobs are limited it makes more sense -> fail early.
For a lot of parallelism it makes more sense to eagerly build the backend.