### PR TITLE
Provide/Inject-pattern for store

### DIFF
--- a/frontend/src/ts/store/user/user.ts
+++ b/frontend/src/ts/store/user/user.ts
@@ -4,36 +4,47 @@
 // of modules (i.e. files), so a class would be pure overhead by adding an
 // artificial layer.
 //-----------------------------------------------------------------------------
-import { ref, computed } from "@vue/composition-api";
-import GreetingService   from "./greeting-service";
+import { ref, computed, provide, inject } from "@vue/composition-api";
+import GreetingService                    from "./greeting-service";
 //-----------------------------------------------------------------------------
-const nameRef         = ref("");
-const messageRef      = ref("");
-const greetingService = new GreetingService();
-//-----------------------------------------------------------------------------
-const name = computed({
-    get: ()  => nameRef.value,
-    set: val => nameRef.value = val
-});
+export function createUserStore() {
+    const nameRef         = ref("");
+    const messageRef      = ref("");
+    const greetingService = new GreetingService();
+    //-------------------------------------------------------------------------
+    const name = computed({
+        get: ()  => nameRef.value,
+        set: val => nameRef.value = val
+    });
 
-const message = computed(() => messageRef.value);
-//-----------------------------------------------------------------------------
-async function hello(): Promise<void> {
-    messageRef.value = await greetingService.hello(nameRef.value);
+    const message = computed(() => messageRef.value);
+    //-------------------------------------------------------------------------
+    async function hello(): Promise<void> {
+        messageRef.value = await greetingService.hello(nameRef.value);
 
-    console.debug("message set to", messageRef.value);
-}
-//-----------------------------------------------------------------------------
-function reset(): void {
-    nameRef.value    = "";
-    messageRef.value = "";
-}
-//-----------------------------------------------------------------------------
-export default function useUserStore() {
+        console.debug("message set to", messageRef.value);
+    }
+    //-------------------------------------------------------------------------
+    function reset(): void {
+        nameRef.value    = "";
+        messageRef.value = "";
+    }
+    //-------------------------------------------------------------------------
     return {
         name,
         message,
         hello,
         reset
     };
+}
+//-----------------------------------------------------------------------------
+// Define a unique key
+const key = Symbol();
+//-----------------------------------------------------------------------------
+export function provideUserStore() {
+    provide(key, createUserStore());
+}
+//-----------------------------------------------------------------------------
+export function useUserStore() {
+    return inject(key);
 }

--- a/frontend/src/ts/store/user/user.ts
+++ b/frontend/src/ts/store/user/user.ts
@@ -7,10 +7,10 @@
 import { ref, computed, provide, inject } from "@vue/composition-api";
 import GreetingService                    from "./greeting-service";
 //-----------------------------------------------------------------------------
-export function createUserStore() {
+export function createUserStore(greetingServiceInjected?: GreetingService) {
     const nameRef         = ref("");
     const messageRef      = ref("");
-    const greetingService = new GreetingService();
+    const greetingService = greetingServiceInjected ?? new GreetingService();
     //-------------------------------------------------------------------------
     const name = computed({
         get: ()  => nameRef.value,
@@ -30,21 +30,26 @@ export function createUserStore() {
         messageRef.value = "";
     }
     //-------------------------------------------------------------------------
-    return {
+    const store = {
         name,
         message,
         hello,
         reset
     };
+
+    return store;
 }
+//-----------------------------------------------------------------------------
+// Note: declare is optional
+declare type UserStore = ReturnType<typeof createUserStore>;
 //-----------------------------------------------------------------------------
 // Define a unique key
 const key = Symbol();
 //-----------------------------------------------------------------------------
-export function provideUserStore() {
-    provide(key, createUserStore());
+export function provideUserStore(greetingService?: GreetingService) {
+    provide(key, createUserStore(greetingService));
 }
 //-----------------------------------------------------------------------------
 export function useUserStore() {
-    return inject(key);
+    return inject(key) as UserStore;
 }

--- a/frontend/src/ts/store/user/user.ts
+++ b/frontend/src/ts/store/user/user.ts
@@ -8,32 +8,46 @@ import { ref, computed, provide, inject } from "@vue/composition-api";
 import GreetingService                    from "./greeting-service";
 //-----------------------------------------------------------------------------
 export function createUserStore(greetingServiceInjected?: GreetingService) {
-    const nameRef         = ref("");
-    const messageRef      = ref("");
-    const greetingService = greetingServiceInjected ?? new GreetingService();
+    const nameRef           = ref("");
+    const messageRef        = ref("");
+    const messageHistoryRef = ref(new Array<string>());
+    const greetingService   = greetingServiceInjected ?? new GreetingService();
     //-------------------------------------------------------------------------
     const name = computed({
         get: ()  => nameRef.value,
         set: val => nameRef.value = val
     });
 
-    const message = computed(() => messageRef.value);
+    const message        = computed(() => messageRef.value);
+    const messageHistory = computed(() => messageHistoryRef.value);
     //-------------------------------------------------------------------------
     async function hello(): Promise<void> {
-        messageRef.value = await greetingService.hello(nameRef.value);
+        const message = await greetingService.hello(nameRef.value);
+
+        messageRef.value = message;
+        messageHistoryRef.value.push(message);
 
         console.debug("message set to", messageRef.value);
     }
     //-------------------------------------------------------------------------
+    function removeFromHistory(index: number): void {
+        const removed = messageHistoryRef.value.splice(index, 1);
+
+        console.debug("Removed item from history (index, message):", index, removed);
+    }
+    //-------------------------------------------------------------------------
     function reset(): void {
-        nameRef.value    = "";
-        messageRef.value = "";
+        nameRef.value           = "";
+        messageRef.value        = "";
+        messageHistoryRef.value = [];
     }
     //-------------------------------------------------------------------------
     const store = {
         name,
         message,
+        messageHistory,
         hello,
+        removeFromHistory,
         reset
     };
 

--- a/frontend/src/ts/store/user/user.ts
+++ b/frontend/src/ts/store/user/user.ts
@@ -41,7 +41,7 @@ export function createUserStore(greetingServiceInjected?: GreetingService) {
 }
 //-----------------------------------------------------------------------------
 // Note: declare is optional
-declare type UserStore = ReturnType<typeof createUserStore>;
+export declare type UserStore = ReturnType<typeof createUserStore>;
 //-----------------------------------------------------------------------------
 // Define a unique key
 const key = Symbol();

--- a/frontend/src/ts/views/form.vue
+++ b/frontend/src/ts/views/form.vue
@@ -38,7 +38,7 @@
 
 <script lang="ts">
     import { defineComponent } from "@vue/composition-api";
-    import { createUserStore } from "@store/user/user";
+    import { useUserStore }    from "@store/user/user";
     //-------------------------------------------------------------------------
     function throwError(): void {
         throw new Error("Test for unhandled error");
@@ -47,7 +47,7 @@
     const component = defineComponent({
         setup() {
             // Deconstruct for easier use in the view-model
-            const { name, message, hello, reset } = createUserStore();
+            const { name, message, hello, reset } = useUserStore();
 
             // Returns the "view model"
             // All the types returned could come from different places, and they

--- a/frontend/src/ts/views/form.vue
+++ b/frontend/src/ts/views/form.vue
@@ -38,7 +38,7 @@
 
 <script lang="ts">
     import { defineComponent } from "@vue/composition-api";
-    import useUserStore        from "@store/user/user";
+    import { createUserStore } from "@store/user/user";
     //-------------------------------------------------------------------------
     function throwError(): void {
         throw new Error("Test for unhandled error");
@@ -47,7 +47,7 @@
     const component = defineComponent({
         setup() {
             // Deconstruct for easier use in the view-model
-            const { name, message, hello, reset } = useUserStore();
+            const { name, message, hello, reset } = createUserStore();
 
             // Returns the "view model"
             // All the types returned could come from different places, and they

--- a/frontend/src/ts/views/history.vue
+++ b/frontend/src/ts/views/history.vue
@@ -1,0 +1,45 @@
+<template>
+    <b-container>
+        <b-row>
+            <b-col id="historyList" v-if="messageHistory.length > 0">
+                <h5>History of messages</h5>
+
+                <ul>
+                    <li v-for="(item, index) in messageHistory" :key="index" data-test="history">
+                        {{ item }}
+                        <b-button :id    ="'deleteButton_' + index"
+                                  @click ="removeFromHistory(index)"
+                                  variant="outline-secondary"
+                                  size   ="sm">
+                            Remove
+                        </b-button>
+                    </li>
+                </ul>
+            </b-col>
+        </b-row>
+    </b-container>
+</template>
+
+<style lang="less">
+    li {
+        list-style: square;
+    }
+</style>
+
+<script lang="ts">
+    import { defineComponent } from "@vue/composition-api";
+    import { useUserStore }    from "@store/user/user";
+    //-------------------------------------------------------------------------
+    const component = defineComponent({
+        setup() {
+            const { messageHistory, removeFromHistory } = useUserStore();
+
+            return {
+                messageHistory,
+                removeFromHistory
+            };
+        }
+    });
+    //-------------------------------------------------------------------------
+    export default component;
+</script>

--- a/frontend/src/ts/views/main.vue
+++ b/frontend/src/ts/views/main.vue
@@ -3,6 +3,8 @@
         <form-view></form-view>
         <hr />
         <status-view></status-view>
+        <hr />
+        <history-view></history-view>
     </div>
 </template>
 
@@ -11,8 +13,9 @@
     import { defineComponent }  from "@vue/composition-api";
     import { provideUserStore } from "@store/user/user";
     //-------------------------------------------------------------------------
-    import FormView   from "./form.vue";
-    import StatusView from "./status.vue";
+    import FormView    from "./form.vue";
+    import StatusView  from "./status.vue";
+    import HistoryView from "./history.vue";
     //-------------------------------------------------------------------------
     // Fabalouse hack for testing with jest, otherwise there are some build
     // failures which seem strange to me...
@@ -25,7 +28,8 @@
     const component = defineComponent({
         components: {
             FormView,
-            StatusView
+            StatusView,
+            HistoryView
         },
         setup() {
             // This provides an instance of the user-store, which can be used

--- a/frontend/src/ts/views/main.vue
+++ b/frontend/src/ts/views/main.vue
@@ -7,7 +7,9 @@
 </template>
 
 <script lang="ts">
-    import setupBootstrap from "@/setup-bootstrap";
+    import setupBootstrap       from "@/setup-bootstrap";
+    import { defineComponent }  from "@vue/composition-api";
+    import { provideUserStore } from "@store/user/user";
     //-------------------------------------------------------------------------
     import FormView   from "./form.vue";
     import StatusView from "./status.vue";
@@ -20,10 +22,21 @@
         console.debug("Skipping registration of BootstrapVue PlugIn");
     }
     //-------------------------------------------------------------------------
-    export default {
+    const component = defineComponent({
         components: {
             FormView,
             StatusView
+        },
+        setup() {
+            // This provides an instance of the user-store, which can be used
+            // by `useUserStore` and the state is shared.
+            // A different component could create a new store with different
+            // (new) state.
+            // That's the advantage of the provide-inject-pattern over
+            // "global" state in the store.
+            provideUserStore();
         }
-    };
+    });
+    //-------------------------------------------------------------------------
+    export default component;
 </script>

--- a/frontend/src/ts/views/status.vue
+++ b/frontend/src/ts/views/status.vue
@@ -15,11 +15,11 @@
 
 <script lang="ts">
     import { defineComponent } from "@vue/composition-api";
-    import useUserStore        from "@store/user/user";
+    import { createUserStore } from "@store/user/user";
     //-------------------------------------------------------------------------
     const component = defineComponent({
         setup() {
-            const { name, message } = useUserStore();
+            const { name, message } = createUserStore();
 
             return {
                 name,

--- a/frontend/src/ts/views/status.vue
+++ b/frontend/src/ts/views/status.vue
@@ -15,11 +15,11 @@
 
 <script lang="ts">
     import { defineComponent } from "@vue/composition-api";
-    import { createUserStore } from "@store/user/user";
+    import { useUserStore }    from "@store/user/user";
     //-------------------------------------------------------------------------
     const component = defineComponent({
         setup() {
-            const { name, message } = createUserStore();
+            const { name, message } = useUserStore();
 
             return {
                 name,

--- a/frontend/tests/vue/jest.config.js
+++ b/frontend/tests/vue/jest.config.js
@@ -13,6 +13,9 @@ module.exports = {
     testMatch: [
         "**/tests/vue/**/*.ts"
     ],
+    modulePathIgnorePatterns: [
+        "mount-composition.ts"
+    ],
     moduleNameMapper: {
         ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>" }),
         "\\.(css|less)$": "<rootDir>/tests/vue/__mocks__/styleMock.js"

--- a/frontend/tests/vue/mount-composition.ts
+++ b/frontend/tests/vue/mount-composition.ts
@@ -1,0 +1,17 @@
+// Inspired from https://stackoverflow.com/a/60012847/347870
+//-----------------------------------------------------------------------------
+import Vue, { VueConstructor, ComponentOptions } from "vue";
+import { mount }                                 from "@vue/test-utils";
+//-----------------------------------------------------------------------------
+export function mountComposition<V extends Vue>(component: VueConstructor<V>, localVue: typeof Vue, cb: () => any) {
+    const componentOptions = {
+        setup() {
+            return cb();
+        },
+        render(h) {
+            return h(component);
+        }
+    } as ComponentOptions<V>;
+
+    return mount(componentOptions, { localVue });
+}

--- a/frontend/tests/vue/store/user/user-tests.ts
+++ b/frontend/tests/vue/store/user/user-tests.ts
@@ -13,8 +13,8 @@ jest.mock("@store/user/greeting-service", () => {
     };
 });
 //-----------------------------------------------------------------------------
-import useUserStore    from "@store/user/user";
-import GreetingService from "@store/user/greeting-service";
+import { createUserStore } from "@store/user/user";
+import GreetingService     from "@store/user/greeting-service";
 //-----------------------------------------------------------------------------
 const MockedGreetingService = (GreetingService as unknown) as jest.Mock<GreetingService>;
 //-----------------------------------------------------------------------------
@@ -26,7 +26,7 @@ beforeEach(() => {
 describe("UserStore", () => {
     describe("name", () => {
         test("set name", () => {
-            const { name } = useUserStore();
+            const { name } = createUserStore();
 
             name.value = "Himen";
             
@@ -36,40 +36,44 @@ describe("UserStore", () => {
     //-------------------------------------------------------------------------
     describe("hello", () => {
         test("name given --> correct message set", async () => {
-            const { name, hello, message } = useUserStore();
-            name.value = "batman";
+            const userStore = createUserStore();
+            userStore.name.value = "batman";
 
             mockHello.mockResolvedValue("Hi batman");
 
-            await hello();
+            await userStore.hello();
 
             expect(mockHello).toHaveBeenCalledWith("batman");
-            expect(message.value).toBe("Hi batman");
+            expect(userStore.message.value).toBe("Hi batman");
             expect.assertions(2);
         });
         //---------------------------------------------------------------------
         test("different name given --> message set", async () => {
-            const { name, hello, message } = useUserStore();
-            name.value = "clayman";
+            const userStore = createUserStore();
+            userStore.name.value = "clayman";
 
             mockHello.mockResolvedValue("Hi clayman");
 
-            await hello();
+            await userStore.hello();
 
             expect(mockHello).toHaveBeenCalledWith("clayman");
-            expect(message.value).toBe("Hi clayman");
+            expect(userStore.message.value).toBe("Hi clayman");
             expect.assertions(2);
         });
     });
     //-------------------------------------------------------------------------
     describe("reset", () => {
-        test("resets properties", () => {
-            const { reset, name, message } = useUserStore();
+        test("resets properties", async () => {
+            const userStore = createUserStore();
 
-            reset();
+            userStore.name.value = "himen";
+            await userStore.hello();
 
-            expect(name.value)   .toBe("");
-            expect(message.value).toBe("");
+            userStore.reset();
+
+            expect(userStore.name.value)   .toBe("");
+            expect(userStore.message.value).toBe("");
+            expect.assertions(2);
         });
     });
 });

--- a/frontend/tests/vue/store/user/user-tests.ts
+++ b/frontend/tests/vue/store/user/user-tests.ts
@@ -45,7 +45,8 @@ describe("UserStore", () => {
 
             expect(mockHello).toHaveBeenCalledWith("batman");
             expect(userStore.message.value).toBe("Hi batman");
-            expect.assertions(2);
+            expect(userStore.messageHistory.value[0]).toBe("Hi batman");
+            expect.assertions(3);
         });
         //---------------------------------------------------------------------
         test("different name given --> message set", async () => {
@@ -58,7 +59,27 @@ describe("UserStore", () => {
 
             expect(mockHello).toHaveBeenCalledWith("clayman");
             expect(userStore.message.value).toBe("Hi clayman");
-            expect.assertions(2);
+            expect(userStore.messageHistory.value[0]).toBe("Hi clayman");
+            expect.assertions(3);
+        });
+    });
+    //-------------------------------------------------------------------------
+    describe("removeFromHistory", () => {
+        test("empty history --> nothing happens", () => {
+            const userStore = createUserStore();
+
+            userStore.removeFromHistory(1);
+        });
+        //---------------------------------------------------------------------
+        test("filled history --> message removed", async () => {
+            const userStore = createUserStore();
+
+            userStore.name.value = "himen";
+            await userStore.hello();
+
+            userStore.removeFromHistory(0);
+
+            expect(userStore.messageHistory.value.length).toBe(0);
         });
     });
     //-------------------------------------------------------------------------
@@ -73,7 +94,8 @@ describe("UserStore", () => {
 
             expect(userStore.name.value)   .toBe("");
             expect(userStore.message.value).toBe("");
-            expect.assertions(2);
+            expect(userStore.messageHistory.value.length).toBe(0);
+            expect.assertions(3);
         });
     });
 });

--- a/frontend/tests/vue/views/form-tests.ts
+++ b/frontend/tests/vue/views/form-tests.ts
@@ -16,11 +16,13 @@ jest.mock("@store/user/greeting-service", () => {
     };
 });
 //-----------------------------------------------------------------------------
-import FormView                           from "@view/form.vue";
-import GreetingService                    from "@store/user/greeting-service";
-import { mount, createLocalVue, Wrapper } from "@vue/test-utils";
-import BootstrapVue                       from "bootstrap-vue";
-import flushPromises                      from "flush-promises";
+import FormView                    from "@view/form.vue";
+import { provideUserStore }        from "@store/user/user";
+import GreetingService             from "@store/user/greeting-service";
+import { createLocalVue, Wrapper } from "@vue/test-utils";
+import { mountComposition }        from "../mount-composition";
+import BootstrapVue                from "bootstrap-vue";
+import flushPromises               from "flush-promises";
 //-----------------------------------------------------------------------------
 const MockedGreetingService = (GreetingService as unknown) as jest.Mock<GreetingService>;
 //-----------------------------------------------------------------------------
@@ -36,7 +38,9 @@ describe("Main.vue", () => {
         const localVue = createLocalVue();
         localVue.use(BootstrapVue);
 
-        sut = mount(FormView, { localVue });
+        sut = mountComposition(FormView, localVue, () => {
+            provideUserStore();
+        });
     });
     //-------------------------------------------------------------------------
     afterEach(() => {

--- a/frontend/tests/vue/views/history-tests.ts
+++ b/frontend/tests/vue/views/history-tests.ts
@@ -1,0 +1,63 @@
+jest.mock("@store/user/greeting-service", () => {
+    return {
+        __esModule: true,   // necessary for the default export, otherwise MockedGreetingService will have a `default` property
+        default: jest.fn().mockImplementation(() => {
+            return {
+                hello: (name: string) => Promise.resolve(`Hi ${name}`)
+            };
+        })
+    };
+});
+//-----------------------------------------------------------------------------
+import HistoryView                                   from "@view/history.vue";
+import { createLocalVue, Wrapper }                   from "@vue/test-utils";
+import { mountComposition }                          from "../mount-composition";
+import BootstrapVue                                  from "bootstrap-vue";
+import { provideUserStore, useUserStore, UserStore } from "@store/user/user";
+//-----------------------------------------------------------------------------
+describe("History.vue", () => {
+    let sut      : Wrapper<HistoryView>;
+    let userStore: UserStore;
+    //-------------------------------------------------------------------------
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.use(BootstrapVue);
+
+        sut = mountComposition(HistoryView, localVue, () => {
+            provideUserStore();
+            userStore = useUserStore();
+        });
+    });
+    //-------------------------------------------------------------------------
+    afterEach(() => {
+        if (sut) {
+            sut.destroy();
+        }
+    });
+    //-------------------------------------------------------------------------
+    test("empty store --> history not rendered", () => {
+        expect(sut.find("#historyList").exists()).toBe(false);
+    });
+    //-------------------------------------------------------------------------
+    test("message set in store --> history list shown with correct item(s)", async () => {
+        userStore.name.value = "batman";
+        await userStore.hello();
+
+        const dataTestItems = sut.findAll("[data-test='history']");
+
+        expect(sut.find("#historyList").exists()).toBe(true);
+        expect(dataTestItems.length).toBe(1);
+        expect(dataTestItems.at(0).text()).toMatch(/Hi batman/);
+        expect.assertions(3);
+    });
+    //-------------------------------------------------------------------------
+    test("delete history --> item removed", async () => {
+        userStore.name.value = "batman";
+        await userStore.hello();
+
+        const removeButton = sut.get("#deleteButton_0");
+        await removeButton.trigger("click");
+
+        expect(sut.find("#historyList").exists()).toBe(false);
+    });
+});

--- a/frontend/tests/vue/views/status-tests.ts
+++ b/frontend/tests/vue/views/status-tests.ts
@@ -9,19 +9,24 @@ jest.mock("@store/user/greeting-service", () => {
     };
 });
 //-----------------------------------------------------------------------------
-import StatusView                         from "@view/status.vue";
-import { mount, createLocalVue, Wrapper } from "@vue/test-utils";
-import BootstrapVue                       from "bootstrap-vue";
-import useUserStore                       from "@store/user/user";
+import StatusView                                    from "@view/status.vue";
+import { createLocalVue, Wrapper }                   from "@vue/test-utils";
+import { mountComposition }                          from "../mount-composition";
+import BootstrapVue                                  from "bootstrap-vue";
+import { provideUserStore, useUserStore, UserStore } from "@store/user/user";
 //-----------------------------------------------------------------------------
 describe("Status.vue", () => {
-    let sut: Wrapper<StatusView>;
+    let sut      : Wrapper<StatusView>;
+    let userStore: UserStore;
     //-------------------------------------------------------------------------
     beforeEach(() => {
         const localVue = createLocalVue();
         localVue.use(BootstrapVue);
 
-        sut = mount(StatusView, { localVue });
+        sut = mountComposition(StatusView, localVue, () => {
+            provideUserStore();
+            userStore = useUserStore();
+        });
     });
     //-------------------------------------------------------------------------
     afterEach(() => {
@@ -39,7 +44,7 @@ describe("Status.vue", () => {
     });
     //-------------------------------------------------------------------------
     test("name and message set in store --> fields updated", async () => {
-        const { name, hello } = useUserStore();
+        const { name, hello } = userStore;
 
         name.value = "batman";
         await hello();


### PR DESCRIPTION
So far the state was

* "shared global"
* local only -- i.e. for each "use" a new state

With this change the state is encapsulated in a `create...Store`-function, so a fresh state can be obtained (e.g. for testing). With the `provide...Store` / `use...Store` functions a shared state can be managed. A parent component can provide the (shared) state, children can then inject this state.

For the testing the store itself, fresh states can be used, and dependency-injection is possible.

Summarizing, I prefer this provide/inject-pattern over the plain shared state pattern.